### PR TITLE
Added version info to compiled SWF

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Installation (Pre-Built SWF)
 ---------------------------
 
 If you want to use Clippy unmodified, just copy `build/clippy.swf` to your
-`public` directory or wherever your static assets can be found.
+`public` directory or wherever your static assets can be found. The file is 
+compiled for Flash 9 and above.
 
 Installation (Compiling)
 ------------------------


### PR DESCRIPTION
Had a need today to know what version the SWF was compiled for. Based on http://stackoverflow.com/q/4351370/117402 it appears it is compiled for Flash 9 and above; I've updated the README to say so.
